### PR TITLE
feat: 챌린지 API 예시 데이터 추가 및 챌린지 조회 응답 일부 수정

### DIFF
--- a/src/main/java/com/minimo/backend/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/minimo/backend/challenge/api/ChallengeApi.java
@@ -48,7 +48,7 @@ public interface ChallengeApi {
     @AssignUserId
     @DeleteMapping("/{challengeId}")
     ResponseEntity<Void> deleteChallenge(
-            @Parameter(description = "삭제할 챌린지의 고유 ID", required = true)
+            @Parameter(description = "삭제할 챌린지의 고유 ID", required = true, example = "1")
             @PathVariable Long challengeId
     );
 
@@ -92,7 +92,7 @@ public interface ChallengeApi {
     @GetMapping("/{challengeId}")
     public ResponseEntity<ChallengeDetailResponse> getDetail(
             @Parameter(hidden = true) Long userId,
-            @Parameter(description = "상세 조회할 챌린지의 고유 ID", required = true)
+            @Parameter(description = "상세 조회할 챌린지의 고유 ID", required = true, example = "1")
             @PathVariable Long challengeId
     );
 
@@ -119,7 +119,7 @@ public interface ChallengeApi {
     @GetMapping("/collenctions/{challengeId}")
     ResponseEntity<CollectionDetailResponse> getCollectionDetail(
             @Parameter(hidden = true) Long userId,
-            @Parameter(description = "조회할 챌린지의 고유 ID", required = true)
+            @Parameter(description = "조회할 챌린지의 고유 ID", required = true, example = "1")
             @PathVariable Long challengeId
     );
 }

--- a/src/main/java/com/minimo/backend/challenge/dto/request/CreateChallengeRequest.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/request/CreateChallengeRequest.java
@@ -1,5 +1,6 @@
 package com.minimo.backend.challenge.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -11,13 +12,17 @@ public class CreateChallengeRequest {
 
     @NotBlank
     @Size(max=20)
+    @Schema(description = "챌린지 제목", example = "하마가 될래요")
     private String title;
 
     @NotBlank
     @Size(max=50)
+    @Schema(description = "챌린지 내용", example = "하루에 물 2L 마시기")
     private String content;
 
+    @Schema(description = "챌린지 진행 기간", example = "7")
     private int durationDays;
 
+    @Schema(description = "챌린지 아이콘", example = "pencil")
     private String challengeIcon;
 }

--- a/src/main/java/com/minimo/backend/challenge/dto/request/FindChallengeRequest.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/request/FindChallengeRequest.java
@@ -1,6 +1,7 @@
 package com.minimo.backend.challenge.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,5 +14,6 @@ public class FindChallengeRequest {
 
     @NotNull(message = "조회할 날짜는 필수입니다.")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @Schema(description = "챌린지 목록을 조회할 날짜", example = "2025-08-25")
     private LocalDate date;
 }

--- a/src/main/java/com/minimo/backend/challenge/dto/response/ChallengeDetailResponse.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/response/ChallengeDetailResponse.java
@@ -1,6 +1,7 @@
 package com.minimo.backend.challenge.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,11 +11,23 @@ import java.util.List;
 @Getter
 @Builder
 public class ChallengeDetailResponse {
+
+    @Schema(description = "챌린지 제목", example = "매일 상쾌한 아침을 위해 물마시기")
     private String title;
+
+    @Schema(description = "챌린지 내용", example = "아침에 물 500ml 마시기")
     private String content;
+
+    @Schema(description = "챌린지 아이콘", example = "water")
     private String challengeIcon;
+
+    @Schema(description = "남은 챌린지 일수", example = "5")
     private long remainingDays;
+
+    @Schema(description = "챌린지 달성률(%)", example = "90")
     private int achievementRate;
+
+    @Schema(description = "챌린지 인증 여부", example = "certified")
     private String status;
 
     private List<CertificationSummary> certifications;
@@ -22,10 +35,17 @@ public class ChallengeDetailResponse {
     @Getter
     @Builder
     public static class CertificationSummary {
+
+        @Schema(description = "인증 이미지 URL", example = "https://example.com/image.jpg")
         private String imageUrl;
+
+        @Schema(description = "인증글 제목", example = "DAY1 인증글")
         private String title;
+
+        @Schema(description = "인증글 내용", example = "첫 걸음을 내딛다!")
         private String content;
 
+        @Schema(description = "인증 등록 날짜", example = "2025-08-25")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
         private LocalDate createdAt;
     }

--- a/src/main/java/com/minimo/backend/challenge/dto/response/ChallengePendingListResponse.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/response/ChallengePendingListResponse.java
@@ -1,5 +1,6 @@
 package com.minimo.backend.challenge.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,16 @@ import java.util.Map;
 @Getter
 @Builder
 public class ChallengePendingListResponse {
+
+    @Schema(
+            description = "주간 캘린더의 요일별 챌린지 인증 아이콘 목록",
+            example = "{ \"MONDAY\": [\"water\", \"run\"], \"TUESDAY\": [\"book\"] }"
+    )
     private Map<DayOfWeek, List<String>> weeklyIcons;
+
+    @Schema(
+            description = "사용자가 진행 중인 챌린지 목록",
+            implementation = ChallengePendingResponse.class
+    )
     private List<ChallengePendingResponse> challenges;
 }

--- a/src/main/java/com/minimo/backend/challenge/dto/response/ChallengePendingResponse.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/response/ChallengePendingResponse.java
@@ -1,5 +1,6 @@
 package com.minimo.backend.challenge.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,9 +8,18 @@ import lombok.Getter;
 @Builder
 public class ChallengePendingResponse {
 
+    @Schema(description = "챌린지 ID", example = "1")
     private Long id;
+
+    @Schema(description = "챌린지 제목", example = "매일 상쾌한 아침을 위해 물마시기")
     private String title;
+
+    @Schema(description = "챌린지 아이콘", example = "water")
     private String challengeIcon;
+
+    @Schema(description = "챌린지 달성률(%)", example = "75")
     private int achievementRate;
+
+    @Schema(description = "남은 챌린지 일수", example = "5")
     private int remainingDays;
 }

--- a/src/main/java/com/minimo/backend/challenge/dto/response/ChallengePendingResponse.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/response/ChallengePendingResponse.java
@@ -11,5 +11,5 @@ public class ChallengePendingResponse {
     private String title;
     private String challengeIcon;
     private int achievementRate;
-    private int durationDays;
+    private int remainingDays;
 }

--- a/src/main/java/com/minimo/backend/challenge/dto/response/CollectionDetailResponse.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/response/CollectionDetailResponse.java
@@ -1,5 +1,6 @@
 package com.minimo.backend.challenge.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,8 +8,15 @@ import lombok.Getter;
 @Builder
 public class CollectionDetailResponse {
 
+    @Schema(description = "챌린지 제목", example = "매일 상쾌한 아침을 위해 물마시기")
     private String title;
+
+    @Schema(description = "챌린지 내용", example = "매일 아침 물 500ml 마시기")
     private String content;
+
+    @Schema(description = "챌린지 아이콘", example = "water")
     private String challengeIcon;
+
+    @Schema(description = "인증 이미지 URL", example = "https://example.com/image.jpg")
     private String imageUrl;
 }

--- a/src/main/java/com/minimo/backend/challenge/dto/response/CollectionResponse.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/response/CollectionResponse.java
@@ -1,5 +1,6 @@
 package com.minimo.backend.challenge.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,8 +10,15 @@ import java.time.LocalDate;
 @Builder
 public class CollectionResponse {
 
+    @Schema(description = "챌린지 고유 ID", example = "1")
     private Long id;
+
+    @Schema(description = "챌린지 제목", example = "매일 상쾌한 아침을 위해 물마시기")
     private String title;
+
+    @Schema(description = "챌린지 아이콘", example = "water")
     private String challengeIcon;
+
+    @Schema(description = "챌린지 종료일", example = "2025-09-02")
     private LocalDate endDate;
 }

--- a/src/main/java/com/minimo/backend/challenge/dto/response/CreateChallengeResponse.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/response/CreateChallengeResponse.java
@@ -3,6 +3,7 @@ package com.minimo.backend.challenge.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.minimo.backend.challenge.domain.Challenge;
 import com.minimo.backend.challenge.domain.ChallengeStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.time.LocalDate;
@@ -10,17 +11,27 @@ import java.time.LocalDate;
 @Getter
 public class CreateChallengeResponse {
 
+    @Schema(description = "챌린지 고유 ID", example = "1")
     private Long id;
+
+    @Schema(description = "챌린지 제목", example = "매일 상쾌한 아침을 위해 물마시기")
     private String title;
+
+    @Schema(description = "챌린지 내용", example = "매일 아침 물 500ml 마시기")
     private String content;
 
+    @Schema(description = "챌린지 시작 날짜", example = "2025-09-01")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startDate;
 
+    @Schema(description = "챌린지 종료 날짜 ", example = "2025-09-30")
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate endDate;
 
+    @Schema(description = "챌린지 아이콘", example = "water")
     private String challengeIcon;
+
+    @Schema(description = "챌린지 상태", example = "ACTIVE")
     private ChallengeStatus status;
 
     public CreateChallengeResponse(Challenge challenge) {

--- a/src/main/java/com/minimo/backend/challenge/service/ChallengeService.java
+++ b/src/main/java/com/minimo/backend/challenge/service/ChallengeService.java
@@ -108,12 +108,15 @@ public class ChallengeService {
                     long postedDays = countMap.getOrDefault(ch.getId(), 0L);
                     int rate = computeAchievementRateSafe(postedDays, totalDays);
 
+                    // 요청 날짜 기준 남은 챌린지 일수 조회
+                    int remainingDays = (int) ChronoUnit.DAYS.between(baseDate, ch.getEndDate());
+
                     return ChallengePendingResponse.builder()
                             .id(ch.getId())
                             .title(Optional.ofNullable(ch.getTitle()).orElse(""))
                             .challengeIcon(Optional.ofNullable(ch.getChallengeIcon()).orElse(""))
                             .achievementRate(rate)
-                            .durationDays(totalDays)
+                            .remainingDays(remainingDays)
                             .build();
                 })
                 .toList();
@@ -172,12 +175,15 @@ public class ChallengeService {
                     long postedDays = countMap.getOrDefault(ch.getId(), 0L);
                     int rate = computeAchievementRateSafe(postedDays, totalDays);
 
+                    // 요청 날짜 기준 남은 챌린지 일수 조회
+                    int remainingDays = (int) ChronoUnit.DAYS.between(baseDate, ch.getEndDate());
+
                     return ChallengePendingResponse.builder()
                             .id(ch.getId())
                             .title(Optional.ofNullable(ch.getTitle()).orElse(""))
                             .challengeIcon(Optional.ofNullable(ch.getChallengeIcon()).orElse(""))
                             .achievementRate(rate)
-                            .durationDays(totalDays)
+                            .remainingDays(remainingDays)
                             .build();
                 })
                 .toList();


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약 -->
- 챌린지 API dto에 예시 데이터를 추가했습니다.
- 인증/미인증 챌린지 조회 시 남은 챌린지 일수를 반환하도록 수정했습니다.

---

## ✨ 작업 상세 내용
<!-- 구체적으로 어떤 기능/수정/개선이 이루어졌는지 -->
- 챌린지 API dto에 예시 데이터 추가
- 인증/미인증 챌린지 조회 시 기존 전체 챌린지 일수에서 남은 챌린지 일수를 반환하도록 변경

---

## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호가 있다면 명시 -->

---

## ✅ 체크리스트
<!-- PR 올리기 전에 스스로 확인하는 항목 -->

---

## 📸 스크린샷 (선택)
<!-- UI 작업이나 API 응답 캡쳐 필요 시 첨부 -->

---

## 📝 기타
<!-- 리뷰어가 알아야 할 추가 사항 -->

