### PR TITLE
docs: 챌린지 API 스웨거 응답 데이터 추가

### DIFF
--- a/src/main/java/com/minimo/backend/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/minimo/backend/challenge/api/ChallengeApi.java
@@ -8,8 +8,12 @@ import com.minimo.backend.global.config.swagger.SwaggerApiFailedResponse;
 import com.minimo.backend.global.config.swagger.SwaggerApiResponses;
 import com.minimo.backend.global.config.swagger.SwaggerApiSuccessResponse;
 import com.minimo.backend.global.exception.ExceptionType;
+import com.minimo.backend.token.dto.response.TokenResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.data.repository.query.Param;
@@ -32,6 +36,7 @@ public interface ChallengeApi {
                     response = CreateChallengeResponse.class),
             errors = @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND)
     )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = CreateChallengeResponse.class)))
     @AssignUserId
     @PostMapping
     ResponseEntity<CreateChallengeResponse> createChallenge(
@@ -63,6 +68,7 @@ public interface ChallengeApi {
                 description = "미인증 챌린지 목록 조회 성공",
                 response = ChallengePendingListResponse.class)
     )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ChallengePendingListResponse.class)))
     @AssignUserId
     @GetMapping("/not-certified")
     ResponseEntity<ChallengePendingListResponse> getNotCertified(
@@ -79,6 +85,7 @@ public interface ChallengeApi {
                     description = "인증한 챌린지 목록 조회 성공",
                     response = ChallengePendingListResponse.class)
     )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ChallengePendingListResponse.class)))
     @AssignUserId
     @GetMapping("/certified")
     ResponseEntity<ChallengePendingListResponse> getCertified(
@@ -96,6 +103,7 @@ public interface ChallengeApi {
                     response = ChallengeDetailResponse.class),
             errors = @SwaggerApiFailedResponse(ExceptionType.CHALLENGE_NOT_FOUND)
     )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ChallengeDetailResponse.class)))
     @AssignUserId
     @GetMapping("/{challengeId}")
     public ResponseEntity<ChallengeDetailResponse> getDetail(
@@ -113,6 +121,7 @@ public interface ChallengeApi {
                     description = "컬렉션 목록 조회 성공",
                     response = CollectionResponse.class)
     )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = CollectionResponse.class)))
     @AssignUserId
     @GetMapping("/collections")
     ResponseEntity<List<CollectionResponse>> getCollections(@Parameter(hidden = true) Long userId);
@@ -127,6 +136,7 @@ public interface ChallengeApi {
                 response = CollectionResponse.class),
         errors = @SwaggerApiFailedResponse(ExceptionType.CHALLENGE_NOT_FOUND)
     )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = CollectionDetailResponse.class)))
     @AssignUserId
     @GetMapping("/collenctions/{challengeId}")
     ResponseEntity<CollectionDetailResponse> getCollectionDetail(
@@ -144,6 +154,7 @@ public interface ChallengeApi {
                     description = "챌린지 목록 조회 성공",
                     response = ActiveChallengeResponse.class)
     )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ActiveChallengeResponse.class)))
     @AssignUserId
     @GetMapping("/active")
     ResponseEntity<List<ActiveChallengeResponse>> getMyActiveChallenges(


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약 -->
- 챌린지 API 스웨거 응답 데이터를 추가했습니다.
- 챌린지 API 스웨거 응답 dto 스키마를 추가했습니다.

---

## ✨ 작업 상세 내용
<!-- 구체적으로 어떤 기능/수정/개선이 이루어졌는지 -->
- 스웨거 챌린지 API에 스웨거 응답 데이터 형식을 추가
- 스웨거 챌린지 API 응답 데이터 dto 스키마 추가

---

## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호가 있다면 명시 -->

---

## ✅ 체크리스트
<!-- PR 올리기 전에 스스로 확인하는 항목 -->
- [ ] 코드에 불필요한 주석/로그가 없음
- [ ] 기능 동작을 직접 확인했음
- [ ] 관련 테스트 코드를 작성했음
- [ ] 문서(README, API 명세 등) 업데이트 완료

---

## 📸 스크린샷 (선택)
<!-- UI 작업이나 API 응답 캡쳐 필요 시 첨부 -->

---

## 📝 기타
<!-- 리뷰어가 알아야 할 추가 사항 -->
