### PR TITLE
fix: 인증 피드 조회 페이지네이션 적용 및 관련 구조 개선

### DIFF
--- a/src/main/java/com/minimo/backend/certification/api/CertificationApi.java
+++ b/src/main/java/com/minimo/backend/certification/api/CertificationApi.java
@@ -11,6 +11,7 @@ import com.minimo.backend.global.config.swagger.SwaggerApiFailedResponse;
 import com.minimo.backend.global.config.swagger.SwaggerApiResponses;
 import com.minimo.backend.global.config.swagger.SwaggerApiSuccessResponse;
 import com.minimo.backend.global.exception.ExceptionType;
+import com.minimo.backend.global.response.GlobalPageResponse;
 import com.minimo.backend.global.response.ResponseBody;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -82,7 +83,7 @@ public interface CertificationApi {
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
                     description = "피드 조회 성공",
-                    response = CertificationFeedResponse.class
+                    responsePage = CertificationFeedResponse.class
             ),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
@@ -91,7 +92,7 @@ public interface CertificationApi {
     @AssignUserId
     @GetMapping("/feed")
     @PreAuthorize("isAuthenticated()")
-    ResponseEntity<ResponseBody<List<CertificationFeedResponse>>> getFeed(
+    ResponseEntity<ResponseBody<GlobalPageResponse<CertificationFeedResponse>>> getFeed(
             @Parameter(hidden = true) Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size

--- a/src/main/java/com/minimo/backend/certification/controller/CertificationController.java
+++ b/src/main/java/com/minimo/backend/certification/controller/CertificationController.java
@@ -9,6 +9,7 @@ import com.minimo.backend.certification.dto.response.CreateCertificationResponse
 import com.minimo.backend.certification.dto.response.UpdateCertificationResponse;
 import com.minimo.backend.certification.service.CertificationService;
 import com.minimo.backend.global.aop.AssignUserId;
+import com.minimo.backend.global.response.GlobalPageResponse;
 import com.minimo.backend.global.response.ResponseBody;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -56,12 +57,12 @@ public class CertificationController implements CertificationApi {
     @AssignUserId
     @GetMapping("/feed")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ResponseBody<List<CertificationFeedResponse>>> getFeed(
+    public ResponseEntity<ResponseBody<GlobalPageResponse<CertificationFeedResponse>>> getFeed(
             Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ) {
-        List<CertificationFeedResponse> feed = certificationService.getFeed(userId, page, size);
+        GlobalPageResponse<CertificationFeedResponse> feed = certificationService.getFeed(userId, page, size);
         return ResponseEntity.ok(createSuccessResponse(feed));
     }
 

--- a/src/main/java/com/minimo/backend/certification/dto/response/CertificationFeedResponse.java
+++ b/src/main/java/com/minimo/backend/certification/dto/response/CertificationFeedResponse.java
@@ -1,16 +1,18 @@
 package com.minimo.backend.certification.dto.response;
 
 import com.minimo.backend.certification.domain.EmojiType;
+import com.minimo.backend.global.response.GlobalPageResponse;
+import com.querydsl.core.annotations.QueryProjection;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.query.Page;
 
 import java.util.Map;
 
 @Getter
 @Setter
-@AllArgsConstructor
 public class CertificationFeedResponse {
 
     @Schema(description = "인증글 고유 ID", example = "1")
@@ -41,4 +43,18 @@ public class CertificationFeedResponse {
 
     @Schema(description = "종류별 응원 개수")
     private Map<EmojiType, Integer> reactionCounts;
+
+
+    @QueryProjection
+    public CertificationFeedResponse(Long certificationId, String title, String content, String imageUrl, Long authorId, String authorNickname, String authorPicture, int totalReactions, Map<EmojiType, Integer> reactionCounts) {
+        this.certificationId = certificationId;
+        this.title = title;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.authorId = authorId;
+        this.authorNickname = authorNickname;
+        this.authorPicture = authorPicture;
+        this.totalReactions = totalReactions;
+        this.reactionCounts = reactionCounts;
+    }
 }

--- a/src/main/java/com/minimo/backend/certification/repository/CertificationRepositoryCustom.java
+++ b/src/main/java/com/minimo/backend/certification/repository/CertificationRepositoryCustom.java
@@ -1,10 +1,11 @@
 package com.minimo.backend.certification.repository;
 
 import com.minimo.backend.certification.dto.response.CertificationFeedResponse;
+import com.minimo.backend.global.response.GlobalPageResponse;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface CertificationRepositoryCustom {
-    List<CertificationFeedResponse> findCertificationFeed(Long userId, Pageable pageable);
+    GlobalPageResponse<CertificationFeedResponse> findCertificationFeed(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/minimo/backend/certification/repository/CertificationRepositoryCustomImpl.java
+++ b/src/main/java/com/minimo/backend/certification/repository/CertificationRepositoryCustomImpl.java
@@ -3,8 +3,11 @@ package com.minimo.backend.certification.repository;
 import com.minimo.backend.certification.domain.QCertification;
 import com.minimo.backend.certification.domain.QReaction;
 import com.minimo.backend.certification.dto.response.CertificationFeedResponse;
+import com.minimo.backend.global.response.GlobalPageResponse;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -18,19 +21,19 @@ public class CertificationRepositoryCustomImpl implements CertificationRepositor
     }
 
     @Override
-    public List<CertificationFeedResponse> findCertificationFeed(Long userId, Pageable pageable) {
+    public GlobalPageResponse<CertificationFeedResponse> findCertificationFeed(Long userId, Pageable pageable) {
         QCertification c = QCertification.certification;
         QReaction r = QReaction.reaction;
 
-        return jpaQueryFactory
+        List<CertificationFeedResponse> content = jpaQueryFactory
                 .select(Projections.bean(CertificationFeedResponse.class,
                         c.id.as("certificationId"),
                         c.title,
                         c.content,
                         c.imageUrl,
-                        c.user.id.as("userId"),
-                        c.user.nickname,
-                        c.user.picture,
+                        c.user.id.as("authorId"),
+                        c.user.nickname.as("authorNickname"),
+                        c.user.picture.as("authorPicture"),
                         r.countDistinct().intValue().as("totalReactions")
                 ))
                 .from(c)
@@ -40,5 +43,19 @@ public class CertificationRepositoryCustomImpl implements CertificationRepositor
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
+
+        // 전체 카운트
+        Long total = jpaQueryFactory
+                .select(c.count())
+                .from(c)
+                .fetchOne();
+
+        if (total == null) {
+            total = 0L; // NPE 방지
+        }
+
+        Page<CertificationFeedResponse> page = new PageImpl<>(content, pageable, total);
+
+        return GlobalPageResponse.create(page);
     }
 }

--- a/src/main/java/com/minimo/backend/certification/service/CertificationService.java
+++ b/src/main/java/com/minimo/backend/certification/service/CertificationService.java
@@ -16,6 +16,7 @@ import com.minimo.backend.challenge.repository.ChallengeRepository;
 import com.minimo.backend.global.config.cloudinary.CloudinaryImageService;
 import com.minimo.backend.global.exception.BusinessException;
 import com.minimo.backend.global.exception.ExceptionType;
+import com.minimo.backend.global.response.GlobalPageResponse;
 import com.minimo.backend.user.domain.User;
 import com.minimo.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -199,7 +200,7 @@ public class CertificationService {
     }
 
     @Transactional(readOnly = true)
-    public List<CertificationFeedResponse> getFeed(Long userId, int page, int size) {
+    public GlobalPageResponse<CertificationFeedResponse> getFeed(Long userId, int page, int size) {
         return certificationRepository.findCertificationFeed(userId, PageRequest.of(page, size));
     }
 


### PR DESCRIPTION
## 📌 작업 개요

- 인증 피드 조회 기능에 페이지네이션 적용 및 관련 API/Controller/DTO/Repository 수정

---

## ✨ 작업 상세 내용

- CertificationFeedResponse 필드 수정 
- CertificationApi, CertificationController에서 getFeed 반환 타입을 GlobalPageResponse로 변경
- CertificationRepositoryCustomImpl에서 QueryDSL 활용한 페이지네이션 구현
- CertificationService에서 getFeed 서비스 로직 페이지네이션 적용

---

## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호가 있다면 명시 -->
- close #이슈번호

---

## ✅ 체크리스트
<!-- PR 올리기 전에 스스로 확인하는 항목 -->
- [ ] 코드에 불필요한 주석/로그가 없음
- [ ] 기능 동작을 직접 확인했음
- [ ] 관련 테스트 코드를 작성했음
- [ ] 문서(README, API 명세 등) 업데이트 완료

---

## 📸 스크린샷 (선택)
<!-- UI 작업이나 API 응답 캡쳐 필요 시 첨부 -->

---

## 📝 기타
<!-- 리뷰어가 알아야 할 추가 사항 -->
-
