### PR TITLE
fix: 피드 조회 DTO 및 리포지토리 매핑 로직 개선

### DIFF
--- a/src/main/java/com/minimo/backend/certification/dto/response/CertificationFeedResponse.java
+++ b/src/main/java/com/minimo/backend/certification/dto/response/CertificationFeedResponse.java
@@ -9,10 +9,12 @@ import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.query.Page;
 
+import java.util.List;
 import java.util.Map;
 
 @Getter
 @Setter
+@Schema(name = "CertificationFeedResponse", description = "인증 피드 응답 DTO")
 public class CertificationFeedResponse {
 
     @Schema(description = "인증글 고유 ID", example = "1")
@@ -42,11 +44,11 @@ public class CertificationFeedResponse {
     private int totalReactions;
 
     @Schema(description = "종류별 응원 개수")
-    private Map<EmojiType, Integer> reactionCounts;
+    private List<ReactionCountResponse> reactionCounts;
 
 
     @QueryProjection
-    public CertificationFeedResponse(Long certificationId, String title, String content, String imageUrl, Long authorId, String authorNickname, String authorPicture, int totalReactions, Map<EmojiType, Integer> reactionCounts) {
+    public CertificationFeedResponse(Long certificationId, String title, String content, String imageUrl, Long authorId, String authorNickname, String authorPicture, int totalReactions, List<ReactionCountResponse> reactionCounts) {
         this.certificationId = certificationId;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/minimo/backend/certification/dto/response/ReactionCountResponse.java
+++ b/src/main/java/com/minimo/backend/certification/dto/response/ReactionCountResponse.java
@@ -1,0 +1,22 @@
+package com.minimo.backend.certification.dto.response;
+
+import com.minimo.backend.certification.domain.EmojiType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(name = "ReactionCount", description = "종류별 응원 개수 DTO")
+public class ReactionCountResponse {
+
+    @Schema(description = "응원 종류", example = "LIKE")
+    private EmojiType type;
+
+    @Schema(description = "응원 개수", example = "3")
+    private int count;
+}

--- a/src/main/java/com/minimo/backend/certification/repository/CertificationRepositoryCustomImpl.java
+++ b/src/main/java/com/minimo/backend/certification/repository/CertificationRepositoryCustomImpl.java
@@ -3,56 +3,95 @@ package com.minimo.backend.certification.repository;
 import com.minimo.backend.certification.domain.QCertification;
 import com.minimo.backend.certification.domain.QReaction;
 import com.minimo.backend.certification.dto.response.CertificationFeedResponse;
+import com.minimo.backend.certification.dto.response.ReactionCountResponse;
 import com.minimo.backend.global.response.GlobalPageResponse;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
+@RequiredArgsConstructor // 생성자 주입을 위해 변경
 public class CertificationRepositoryCustomImpl implements CertificationRepositoryCustom {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public CertificationRepositoryCustomImpl(JPAQueryFactory jpaQueryFactory) {
-        this.jpaQueryFactory = jpaQueryFactory;
-    }
-
     @Override
     public GlobalPageResponse<CertificationFeedResponse> findCertificationFeed(Long userId, Pageable pageable) {
         QCertification c = QCertification.certification;
-        QReaction r = QReaction.reaction;
 
+        // 페이징을 적용하여 Certification의 기본 정보만 조회 (Join 없음)
         List<CertificationFeedResponse> content = jpaQueryFactory
-                .select(Projections.bean(CertificationFeedResponse.class,
-                        c.id.as("certificationId"),
+                .select(Projections.constructor(
+                        CertificationFeedResponse.class,
+                        c.id,
                         c.title,
                         c.content,
                         c.imageUrl,
-                        c.user.id.as("authorId"),
-                        c.user.nickname.as("authorNickname"),
-                        c.user.picture.as("authorPicture"),
-                        r.countDistinct().intValue().as("totalReactions")
+                        c.user.id,
+                        c.user.nickname,
+                        c.user.picture,
+                        Expressions.constant(0),
+                        Expressions.nullExpression(List.class)
                 ))
                 .from(c)
-                .leftJoin(r).on(r.certification.eq(c))
-                .groupBy(c.id, c.title, c.content, c.imageUrl, c.user.id, c.user.nickname, c.user.picture)
                 .orderBy(c.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        // 전체 카운트
-        Long total = jpaQueryFactory
-                .select(c.count())
-                .from(c)
-                .fetchOne();
-
-        if (total == null) {
-            total = 0L; // NPE 방지
+        // 조회된 인증글이 없다면 바로 반환
+        if (content.isEmpty()) {
+            // PageImpl을 사용하여 비어있는 Page 객체 생성
+            Page<CertificationFeedResponse> emptyPage = new PageImpl<>(List.of(), pageable, 0);
+            return GlobalPageResponse.create(emptyPage); // 기존 create 메소드 사용
         }
+
+        // 인증글 ID 리스트 추출
+        List<Long> certificationIds = content.stream()
+                .map(CertificationFeedResponse::getCertificationId)
+                .toList();
+
+        QReaction r = QReaction.reaction;
+
+        // 조회된 인증글 ID에 해당하는 모든 Reaction 정보를 한 번에 조회
+        List<Tuple> reactionTuples = jpaQueryFactory
+                .select(r.certification.id, r.emojiType, r.count())
+                .from(r)
+                .where(r.certification.id.in(certificationIds))
+                .groupBy(r.certification.id, r.emojiType)
+                .fetch();
+
+        // 인증글 ID를 key로, ReactionCountResponse 리스트를 value로 하는 Map 생성
+        Map<Long, List<ReactionCountResponse>> reactionMap = reactionTuples.stream()
+                .collect(Collectors.groupingBy(
+                        t -> t.get(r.certification.id),
+                        Collectors.mapping(
+                                t -> new ReactionCountResponse(t.get(r.emojiType), t.get(r.count()).intValue()),
+                                Collectors.toList()
+                        )
+                ));
+
+        //  메모리에서 데이터 조합 (Reaction 정보 주입)
+        content.forEach(feed -> {
+            List<ReactionCountResponse> reactionCounts = reactionMap.getOrDefault(feed.getCertificationId(), List.of());
+            int totalReactions = reactionCounts.stream()
+                    .mapToInt(ReactionCountResponse::getCount)
+                    .sum();
+            feed.setReactionCounts(reactionCounts);
+            feed.setTotalReactions(totalReactions);
+        });
+
+        // 전체 카운트 쿼리
+        Long total = jpaQueryFactory.select(c.count()).from(c).fetchOne();
+        if (total == null) total = 0L;
 
         Page<CertificationFeedResponse> page = new PageImpl<>(content, pageable, total);
 


### PR DESCRIPTION
## 📌 작업 개요

### 문제 요약

1. Swagger/OpenAPI에서 **Map<EmojiType, Integer>** 같은 복합 타입을 `$ref`로 처리할 수 없음.
    - OpenAPI 스펙에서는 `Map`은 명시적으로 `additionalProperties`로 선언해야 합니다.
2. DTO에 **`@Schema`만 붙여놨지만 클래스 레벨 `@Schema`가 없어서** 스캔이 제대로 안 될 수 있음.
3. DTO가 **패키지 스캔 범위 밖**에 있으면 Swagger에서 참조하지 못함.

---

## ✨ 작업 상세 내용

- 클래스에 `@Schema(name=...)` 추가
- Map 타입은 Swagger가 이해할 수 있도록 변환
- 기본 생성자 추가
- 패키지 스캔 확인

---

## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호가 있다면 명시 -->
- close #이슈번호

---

## ✅ 체크리스트
<!-- PR 올리기 전에 스스로 확인하는 항목 -->
- [ ] 코드에 불필요한 주석/로그가 없음
- [ ] 기능 동작을 직접 확인했음
- [ ] 관련 테스트 코드를 작성했음
- [ ] 문서(README, API 명세 등) 업데이트 완료

---

## 📸 스크린샷 (선택)
<!-- UI 작업이나 API 응답 캡쳐 필요 시 첨부 -->

---

## 📝 기타
<!-- 리뷰어가 알아야 할 추가 사항 -->
-
