### PR TITLE
feat: 챌린지 상세 조회 시 전체 일수, 인증글 수 반환

### DIFF
--- a/src/main/java/com/minimo/backend/challenge/dto/response/ChallengeDetailResponse.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/response/ChallengeDetailResponse.java
@@ -25,7 +25,13 @@ public class ChallengeDetailResponse {
     @Schema(description = "남은 챌린지 일수", example = "5")
     private long remainingDays;
 
-    @Schema(description = "챌린지 달성률(%)", example = "90")
+    @Schema(description = "진행한 인증 개수", example = "20")
+    private long certificationCount;
+
+    @Schema(description = "전체 챌린지 일수", example = "25")
+    private long totalChallengeDays;
+
+    @Schema(description = "챌린지 달성률(%)", example = "80")
     private int achievementRate;
 
     @Schema(description = "챌린지 인증 여부", example = "certified")

--- a/src/main/java/com/minimo/backend/challenge/service/ChallengeService.java
+++ b/src/main/java/com/minimo/backend/challenge/service/ChallengeService.java
@@ -264,6 +264,8 @@ public class ChallengeService {
         List<Certification> myCerts = certificationRepository
                 .findByChallenge_IdAndUser_IdOrderByCreatedAtDesc(challengeId, userId);
 
+        long certificationCount = myCerts.size();
+
         // 인증글 ID 목록
         List<Long> certIds = myCerts.stream()
                 .map(Certification::getId)
@@ -319,6 +321,8 @@ public class ChallengeService {
                 .remainingDays(remainingDays)
                 .achievementRate(achievementRate)
                 .certifications(certSummaries)
+                .totalChallengeDays(durationDays)
+                .certificationCount(certificationCount)
                 .status(status)
                 .build();
     }


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약 -->
- 챌린지 상세 조회 API 요청 시 전체 일수, 인증글 개수를 반환합니다.

---

## ✨ 작업 상세 내용
<!-- 구체적으로 어떤 기능/수정/개선이 이루어졌는지 -->
- 챌린지 상세 조회 dto 수정
- ChallengeService에서 전체 일수, 인증글 개수를 카운트 후 dto에 담아 반환

---

## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호가 있다면 명시 -->

---

## ✅ 체크리스트
<!-- PR 올리기 전에 스스로 확인하는 항목 -->


---

## 📸 스크린샷 (선택)
<!-- UI 작업이나 API 응답 캡쳐 필요 시 첨부 -->

---

## 📝 기타
<!-- 리뷰어가 알아야 할 추가 사항 -->

