### PR TITLE
feat: 인증/미인증 챌린지 조회 날짜 입력 QueryString으로 변경

### DIFF
--- a/src/main/java/com/minimo/backend/challenge/api/ChallengeApi.java
+++ b/src/main/java/com/minimo/backend/challenge/api/ChallengeApi.java
@@ -73,7 +73,7 @@ public interface ChallengeApi {
     @GetMapping("/not-certified")
     ResponseEntity<ChallengePendingListResponse> getNotCertified(
             @Parameter(hidden = true) Long userId,
-            @Valid @RequestBody FindChallengeRequest request
+            @Valid @ModelAttribute FindChallengeRequest request
     );
 
     @Operation(
@@ -90,7 +90,7 @@ public interface ChallengeApi {
     @GetMapping("/certified")
     ResponseEntity<ChallengePendingListResponse> getCertified(
             @Parameter(hidden = true) Long userId,
-            @Valid @RequestBody FindChallengeRequest request
+            @Valid @ModelAttribute FindChallengeRequest request
     );
 
     @Operation(

--- a/src/main/java/com/minimo/backend/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/minimo/backend/challenge/controller/ChallengeController.java
@@ -41,9 +41,8 @@ public class ChallengeController implements ChallengeApi {
     @GetMapping("/not-certified")
     public ResponseEntity<ChallengePendingListResponse> getNotCertified(
             @AuthenticationPrincipal Long userId,
-            @Valid @RequestBody FindChallengeRequest request
+            @Valid @ModelAttribute FindChallengeRequest request
     ) {
-        System.out.println("API 실행");
         ChallengePendingListResponse response = challengeService.findNotCertified(userId, request);
 
         return ResponseEntity.ok(response);
@@ -52,7 +51,7 @@ public class ChallengeController implements ChallengeApi {
     @GetMapping("/certified")
     public ResponseEntity<ChallengePendingListResponse> getCertified(
             @AuthenticationPrincipal Long userId,
-            @Valid @RequestBody FindChallengeRequest request) {
+            @Valid @ModelAttribute FindChallengeRequest request) {
         ChallengePendingListResponse response = challengeService.findCertifiedToday(userId, request);
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/minimo/backend/challenge/dto/request/FindChallengeRequest.java
+++ b/src/main/java/com/minimo/backend/challenge/dto/request/FindChallengeRequest.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
@@ -13,7 +14,7 @@ import java.time.LocalDate;
 public class FindChallengeRequest {
 
     @NotNull(message = "조회할 날짜는 필수입니다.")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     @Schema(description = "챌린지 목록을 조회할 날짜", example = "2025-08-25")
     private LocalDate date;
 }


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약 -->
- 인증/미인증 챌린지 조회 날짜 입력 방법을 QueryString으로 변경했습니다.

---

## ✨ 작업 상세 내용
<!-- 구체적으로 어떤 기능/수정/개선이 이루어졌는지 -->
- 날짜 입력 시 기존 RequestBody 방식에서 QueryString 방식으로 변경

---

## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호가 있다면 명시 -->

---

## ✅ 체크리스트
<!-- PR 올리기 전에 스스로 확인하는 항목 -->

---

## 📸 스크린샷 (선택)
<!-- UI 작업이나 API 응답 캡쳐 필요 시 첨부 -->

---

## 📝 기타
<!-- 리뷰어가 알아야 할 추가 사항 -->

