### PR TITLE
feat: 챌린지 삭제 시 인증글 및 리액션 연쇄 삭제 기능 추가

### DIFF
--- a/src/main/java/com/minimo/backend/certification/domain/Certification.java
+++ b/src/main/java/com/minimo/backend/certification/domain/Certification.java
@@ -39,6 +39,6 @@ public class Certification extends BaseEntity {
     @Column(nullable = false, length = 300)
     private String content;
 
-    @OneToMany(mappedBy = "certification", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "certification", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private final List<Reaction> reactions = new ArrayList<>();
 }

--- a/src/main/java/com/minimo/backend/certification/service/CertificationService.java
+++ b/src/main/java/com/minimo/backend/certification/service/CertificationService.java
@@ -92,6 +92,8 @@ public class CertificationService {
                 .imageId(imageId)
                 .build();
 
+        challenge.addCertification(certification);
+
         Certification savedCertification = certificationRepository.save(certification);
 
         long count = certificationRepository.countByChallenge_IdAndUser_Id(challengeId, userId);

--- a/src/main/java/com/minimo/backend/challenge/domain/Challenge.java
+++ b/src/main/java/com/minimo/backend/challenge/domain/Challenge.java
@@ -1,5 +1,6 @@
 package com.minimo.backend.challenge.domain;
 
+import com.minimo.backend.certification.domain.Certification;
 import com.minimo.backend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Entity
@@ -44,6 +47,11 @@ public class Challenge {
     @Column(length = 16)
     private ChallengeStatus status;
 
+    @OneToMany(mappedBy = "challenge",
+            cascade = CascadeType.REMOVE,
+            orphanRemoval = true)
+    private List<Certification> certifications = new ArrayList<>();
+
     @PrePersist
     public void onCreate() {
         if (this.startDate == null) {
@@ -56,5 +64,10 @@ public class Challenge {
 
     public void complete() {
         this.status = ChallengeStatus.COMPLETED;
+    }
+
+    public void addCertification(Certification certification) {
+        this.certifications.add(certification);
+        certification.setChallenge(this);
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
<!-- 어떤 작업을 했는지 한 줄 요약 -->

- 챌린지 삭제 시 인증글 및 리액션 연쇄 삭제 기능 추가

---

## ✨ 작업 상세 내용
<!-- 구체적으로 어떤 기능/수정/개선이 이루어졌는지 -->
- Challenge ↔ Certification 양방향 매핑 추가
- CascadeType.REMOVE, orphanRemoval 설정 적용
- Certification ↔ Reaction 관계에도 연쇄 삭제 보장
- Challenge 엔티티에 addCertification 편의 메서드 추가

---

## 🔗 관련 이슈
<!-- 이 PR이 연결된 이슈 번호가 있다면 명시 -->

---

## ✅ 체크리스트
<!-- PR 올리기 전에 스스로 확인하는 항목 -->


---

## 📸 스크린샷 (선택)
<!-- UI 작업이나 API 응답 캡쳐 필요 시 첨부 -->

---

## 📝 기타
<!-- 리뷰어가 알아야 할 추가 사항 -->

